### PR TITLE
Change HTTP to HTTPS in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
 	<meta charset="utf-8">
 	<title>Refugee Death</title>
-	<script type="text/javascript"src ="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-	<script type="text/javascript"src ="http://d3js.org/topojson.v1.min.js"></script>
+	<script type="text/javascript"src ="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
+	<script type="text/javascript"src ="https://d3js.org/topojson.v1.min.js"></script>
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 </head>
 <body>


### PR DESCRIPTION
Currently https://levitabris.github.io/Refugee-Death-on-EU-border/ is broken, because the website is served over HTTPS but some of the resources are loaded over HTTP.

This MR fixes this by updating the offending URLs to HTTPS.

The code can be seen working at: https://contrib.pother.ca/Refugee-Death-on-EU-border/

Also, very impressive work! :+1: 